### PR TITLE
Fixed header returned to application for Disconnect message control flag reserved bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ This library was modified heavily from https://github.com/plucury/mqtt.go and
 is API-incompatible with it.
 
 Currently the library's API is unstable.
+
+@Update: CONNACK with "session present" flag to support 3.1.1 compliance

--- a/mqtt_test.go
+++ b/mqtt_test.go
@@ -82,13 +82,14 @@ func TestEncodeDecode(t *testing.T) {
 		{
 			Comment: "CONNACK message",
 			Msg: &ConnAck{
+				SessionPresent:true,
 				ReturnCode: RetCodeBadUsernameOrPassword,
 			},
 			Expected: gbt.InOrder{
 				gbt.Named{"Header byte", gbt.Literal{0x20}},
 				gbt.Named{"Remaining length", gbt.Literal{2}},
 
-				gbt.Named{"Reserved byte", gbt.Literal{0}},
+				gbt.Named{"Reserved byte", gbt.Literal{1}},
 				gbt.Named{"Return code", gbt.Literal{4}},
 			},
 		},

--- a/mqtt_test.go
+++ b/mqtt_test.go
@@ -88,8 +88,8 @@ func TestEncodeDecode(t *testing.T) {
 			Expected: gbt.InOrder{
 				gbt.Named{"Header byte", gbt.Literal{0x20}},
 				gbt.Named{"Remaining length", gbt.Literal{2}},
-
-				gbt.Named{"Reserved byte", gbt.Literal{1}},
+				// Session Present: bit 0 of the Connect Acknowledge Flags
+				gbt.Named{"Connect Acknowledge Flags", gbt.Literal{1}},
 				gbt.Named{"Return code", gbt.Literal{4}},
 			},
 		},


### PR DESCRIPTION
Hi Huin, Pls review and approve. This PR returns the header for Disconnect message to the application for the incoming control flag reserved bits validation. As per the protocol they should be 0 